### PR TITLE
fix: scrollbars in FF (scss)

### DIFF
--- a/design/scss/content.scss
+++ b/design/scss/content.scss
@@ -228,7 +228,7 @@
     background: var(--nav-bg);
     max-height: 80vh;
     margin-top: 1em;
-    overflow-y: scroll;
+    overflow-y: auto;
     position: sticky;
     top: 20px;
     box-shadow: var(--toc-shadow);
@@ -314,7 +314,7 @@ video, video-player, .video-overlay {
   .content-main {
     position: static;
     width: 100%;
-    
+
   }
   .toc {
     margin-left: 0;

--- a/design/scss/syntax.scss
+++ b/design/scss/syntax.scss
@@ -22,7 +22,7 @@
 }
 
 .highlight {
-  overflow-x: scroll;
+  overflow-x: auto;
   box-shadow: var(--card-shadow);
 
   @include scrollbar;


### PR DESCRIPTION
Firefox always displays scrollbars when overflow is set to scroll.

![1](https://user-images.githubusercontent.com/32206071/50860290-d3718d80-1395-11e9-876c-c3fff797140c.JPG)
