### PR TITLE
Shortcuts to open and close the search box

### DIFF
--- a/components/src/app/algolia/algolia-search/algolia-search.component.html
+++ b/components/src/app/algolia/algolia-search/algolia-search.component.html
@@ -1,7 +1,7 @@
 <div class="algolia-search" [class.algolia-show]="visible">
 
   <div class="algolia-hits">
-      <input (keydown.esc)="hide()"
+      <input
         placeholder="explore..." class="algolia-input" type="text" #searchInput (keyup)="handleSearch(searchInput.value)">
         
         <span (click)="hide()" class="algolia-close btn btn-sm btn-red">close</span>

--- a/components/src/app/algolia/algolia-search/algolia-search.component.ts
+++ b/components/src/app/algolia/algolia-search/algolia-search.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectorRef, ElementRef, AfterViewInit, Input } from '@angular/core';
+import { Component, ChangeDetectorRef, ElementRef, AfterViewInit, Input, HostListener, ViewChild } from '@angular/core';
 import * as algolia from 'algoliasearch/lite';
 
 const APP_ID = '05VYZFXKNM';
@@ -33,12 +33,30 @@ export class AlgoliaSearchComponent implements AfterViewInit  {
   @Input() show = () => this.toggle(true);
   @Input() hide = () => this.toggle(false);
 
+  @ViewChild('searchInput') searchInput:ElementRef;
+
+  @HostListener('document:keydown', ['$event'])
+  keyDownHandler(e: KeyboardEvent) {
+
+    if (e.ctrlKey && e.shiftKey && e.keyCode === 80) {
+      // Ctrl + Shift + P shortcut to open the search box
+      e.preventDefault();
+      this.toggle(true);
+    }
+    else if (e.keyCode === 27) {
+      // ESC to close the search box
+      this.toggle(false);
+    }
+  }
+
   ngAfterViewInit() {
 
   }
 
   toggle(val) {
     this.visible = val;
+    // Focus the input element
+    this.searchInput.nativeElement.focus();
     this.cd.detectChanges();
   }
 


### PR DESCRIPTION
Added following shortcuts:
- <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>P</kbd> to open the search box
- <kbd>ESC</kbd> to close the search box

The input element of the search box is auto-focused when it is opened so that typing flow is maintained.
Fixes #22 