### PR TITLE
link-upstream and sync npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,42 @@ git push origin my-fix
 
 Lastly, open a pull request on Github. Once merged, your changes will automatically be deployed to the live site via the CI/CD pipeline. 
 
+### Keeping Your Fork in Sync
+
+As features are added and fixes are made to the original repo (usually referred to as the 'upstream') your fork will become out of date. You can keep your fork up to date by doing the following:
+
+#### One-Time Setup
+
+Run from your terminal
+
+```
+npm run link-upstream
+```
+
+This should add the official repo as a remote called: 'upstream'. You can see all remotes by entering:
+
+```
+git remote -v
+```
+
+In a typical setup, you should see your fork on Github listed as origin, and the `fireship-io` original as upstream:
+
+```
+origin          https://github.com/ZackDeRose/fireship.io (fetch)
+origin          https://github.com/ZackDeRose/fireship.io (push)
+upstream        https://github.com/fireship-io/fireship.io (fetch)
+upstream        https://github.com/fireship-io/fireship.io (push)
+```
+
+#### Keeping In Sync With the Original
+
+Whenever you believe your fork may be out of sync, just run from your terminal
+
+```
+npm run sync
+```
+
+This will update your local master branch to match the original repo's master branch! It will then push those changes to your fork on GitHub, essentially keeping all 3 in sync!
 
 ### Contribute a Post
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "build:components": "cd components && npm run lint && npm run build",
     "build": "rm -rf public && npm run build:design && npm run build:components && npm run build:hugo",
     "algolia": "atomic-algolia",
-    "deploy": "firebase deploy --debug --token \"$FIREBASE_TOKEN\" --only hosting"
+    "deploy": "firebase deploy --debug --token \"$FIREBASE_TOKEN\" --only hosting",
+    "link-upstream": "git remote add upstream https://github.com/fireship-io/fireship.io",
+    "sync": "git fetch && git checkout master && git merge upstream/master && git push"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Adds 2 npm scripts:

```
"link-upstream": "git remote add upstream https://github.com/fireship-io/fireship.io",
"sync": "git fetch && git checkout master && git merge upstream/master && git push"
```

and explains how to use them in the Readme.md