### PR TITLE
Fixed locked orientation on mobile

### DIFF
--- a/hugo/static/manifest.json
+++ b/hugo/static/manifest.json
@@ -4,7 +4,6 @@
     "description": "Awesome Content for App Developers",
     "start_url": ".",
     "display": "standalone",
-    "orientation" : "portrait",
     "background_color": "#2a2e35",
     "theme_color": "#454e56",
     "icons": [


### PR DESCRIPTION
Videos could only be viewed horizontally and not vertically, because the manifest.json file limited it to only be horizontal.