### PR TITLE
Tiny update to Firebase Builder cli instructions

### DIFF
--- a/hugo/content/lessons/ci-cd-with-google-cloud-build/index.md
+++ b/hugo/content/lessons/ci-cd-with-google-cloud-build/index.md
@@ -106,7 +106,7 @@ gcloud builds submit --config cloudbuild.yaml .
 
 # wait for it to finish, then cleanup...
 
-cd ..
+cd ../..
 rm -rf cloud-builders-community
 {{< /highlight >}}
 


### PR DESCRIPTION
This is a really small change. While running through the "Upload the Firebase Builder" command line steps I notice the `cd` command was one directory off from where you can clean up the cloud-builders-community directory (e.g., `cd ..` -> `cd ../..`).