### PR TITLE
fix: Lowercased 'the' in flutter-firebase/intro-resources

### DIFF
--- a/hugo/content/courses/flutter-firebase/intro-resources.md
+++ b/hugo/content/courses/flutter-firebase/intro-resources.md
@@ -24,5 +24,5 @@ free: true
 
 ## Additional Resources
 
-- [Get it on The App Store](https://itunes.apple.com/us/app/fireship/id1462592372?mt=8)
+- [Get it on the App Store](https://itunes.apple.com/us/app/fireship/id1462592372?mt=8)
 - [Get it on Google Play](https://play.google.com/store/apps/details?id=io.fireship.quizapp)


### PR DESCRIPTION
- made the 'the' of 'the App Store' lowercase. 'The' is not part of the name of the Apple App Store.