### PR TITLE
Update index.md

### DIFF
--- a/hugo/content/lessons/angularfire-google-oauth/index.md
+++ b/hugo/content/lessons/angularfire-google-oauth/index.md
@@ -365,7 +365,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     match /users/{userId} {
-        allow write: if isOwner(userId);
+        allow write, read: if isOwner(userId);
     }
 
     // Reusable function to determine document ownership


### PR DESCRIPTION
The firestore rules is incorrect, it is missing the read permission. If omitted, the user can initially log in the first time but then they would no longer have permission to retrieve their initially captured user data during the authentication process.