### PR TITLE
fix: change startAfter to endBefore

### DIFF
--- a/hugo/content/lessons/firestore-pagination-guide/index.md
+++ b/hugo/content/lessons/firestore-pagination-guide/index.md
@@ -69,7 +69,7 @@ Going back to the previous page requires the the **first** document from current
   function prevPage(first) {
 
 	return ref.orderBy(field)
-			  .startAfter(first[field])
+			  .endBefore(first[field])
 			  .limitToLast(pageSize);
   }
 {{< /highlight >}}


### PR DESCRIPTION
Small typo in the pagination lesson where startAfter is referenced
instead of endBefore.