### PR TITLE
fix: Remove redundant entry of MatButtonModule

### DIFF
--- a/hugo/content/courses/angular/app-shared-module.md
+++ b/hugo/content/courses/angular/app-shared-module.md
@@ -71,7 +71,6 @@ const components = [ShellComponent];
 const modules = [
   CommonModule,
   MatButtonModule,
-  MatButtonModule,
   MatToolbarModule,
   MatIconModule,
   LayoutModule,


### PR DESCRIPTION
MatButtonModule is added twice in the modules array which is redundant