### PR TITLE
fix: copied! is included on second click

### DIFF
--- a/design/index.ts
+++ b/design/index.ts
@@ -84,7 +84,7 @@ declare function gtag(command: 'config' | 'set' | 'event', id: string, config?: 
             }
             const alert = document.getElementById('copied') || createEl();
    
-            el.appendChild(alert);
+            el.parentElement.appendChild(alert);
             alert.classList.add('delayed-fade');
           })
         })


### PR DESCRIPTION
Currently if you click twice on the same code snippet on the second time `copied!` is appended to the clipboard text. Because the alert is currently appended to the `<div class="highlight">`. 

In this fix the alert is added to the parent element and is displayed correctly and `copied!` is not appended to the clipboard text.