### PR TITLE
Addition: Blaze plan required for Algolia

### DIFF
--- a/hugo/content/lessons/algolia-cloud-functions/index.md
+++ b/hugo/content/lessons/algolia-cloud-functions/index.md
@@ -43,6 +43,10 @@ This lesson is integrated with multiple frontend frameworks. After deploying the
 
 ## Initial Setup
 
+### Blaze plan required
+
+Make sure you are at least using the Firebase Blaze plan because this will enable you to make network requests to third-party APIs like Algolia.
+
 ### Initialize Cloud Functions
 
 First, initialize Cloud Functions in your project with the Firebase Tools CLI. This lesson uses vanilla JS, but feel free to select TypeScript if you prefer. 


### PR DESCRIPTION
I followed this tutorial but the cloud function encountered an unspecific error: "Unreachable hosts - your application id may be incorrect ..."
It took me a while to find out that the Spark plan does not allow network calls to third-party APIs like Algolia and thus I switched to the Blaze plan which fixed the problem.