### PR TITLE
fix typo in javascript index

### DIFF
--- a/hugo/content/courses/javascript/_index.md
+++ b/hugo/content/courses/javascript/_index.md
@@ -15,4 +15,4 @@ This course is *beginner to intermediate* level and designed to teach you JavaSc
 
 ### 🔨 Work in Progress
 
-This course is being released in weekly intervals and is current a work in progress. Make sure to [subscribe on YouTube](https://www.youtube.com/channel/UCsBjURrPoezykLs9EqgamOA) to catch the next episode. 
+This course is being released in weekly intervals and is currently a work in progress. Make sure to [subscribe on YouTube](https://www.youtube.com/channel/UCsBjURrPoezykLs9EqgamOA) to catch the next episode. 


### PR DESCRIPTION
I found a typo on the main page for That Weird JavaScript course. This is my first commit to any open source project, so I may not have done everything right. It said the course was, "current a work in progress," instead of currently.