### PR TITLE
Fix Slack Link in Course Footer

### DIFF
--- a/components/src/app/slack-mirror/slack-mirror.component.html
+++ b/components/src/app/slack-mirror/slack-mirror.component.html
@@ -1,7 +1,7 @@
 
 <div class="slack-cmd">
     <p>Have Questions? Let's chat about this post</p>
-    <p><a class="btn btn-purple btn-sm" href="https://goo.gl/8BKA1e">Signup for Slack</a> Copy the link below and paste it into the <strong>#questions</strong> channel in Slack 👇</p>
+    <p><a class="btn btn-purple btn-sm" href="https://fireship.page.link/slack">Signup for Slack</a> Copy the link below and paste it into the <strong>#questions</strong> channel in Slack 👇</p>
     <p><code>{{ qLink }}</code><button (click)="copyCmd" class="btn btn-blue btn-sm" (click)="copyCmd()">
         Copy and Ask
     </button>


### PR DESCRIPTION
https://goo.gl/8BKA1e is not working: "This invite link is no longer active."
Using the Slack signup link from the right-side menu: https://fireship.page.link/slack => It is working.

Old link Screenshot:
<img width="1320" alt="Screenshot 2020-04-10 at 21 28 07" src="https://user-images.githubusercontent.com/23075874/79017688-3b52ed00-7b72-11ea-9946-7e3711c6d012.png">

New link Screenshot:
<img width="1320" alt="Screenshot 2020-04-10 at 21 28 21" src="https://user-images.githubusercontent.com/23075874/79017699-4148ce00-7b72-11ea-835d-ca91e3273619.png">
