### PR TITLE
Typo at ts-decorators-by-example/index.md

### DIFF
--- a/hugo/content/lessons/ts-decorators-by-example/index.md
+++ b/hugo/content/lessons/ts-decorators-by-example/index.md
@@ -59,7 +59,7 @@ function Frozen(constructor: Function) {
 
 console.log(Object.isFrozen(IceCream)); // true
 
-class FroYo extends IceCream {} // error, cannont be extended
+class FroYo extends IceCream {} // error, cannot be extended
 {{< /highlight >}}
 
 


### PR DESCRIPTION
Typo at line 62: "cannont" -> cannot