### PR TITLE
Update footer.html

### DIFF
--- a/hugo/data/links.yaml
+++ b/hugo/data/links.yaml
@@ -1,6 +1,7 @@
 slack: https://fireship.page.link/slack
 github: https://github.com/fireship-io
 github_content: https://github.com/fireship-io/fireship.io/tree/master/hugo/content
+github_submit_fixes: https://github.com/fireship-io/fireship.io/issues/new
 twitter: https://twitter.com/fireship_dev
 youtube: https://www.youtube.com/channel/UCsBjURrPoezykLs9EqgamOA
 gde: https://developers.google.com/community/experts/directory/profile/profile-jeff_delaney

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer>
-    <div class="github-link">Find an issue with this page? <a href="{{ .Site.Data.links.github_content }}/{{ .File.Path }}">Fix it on GitHub</a></div>
+    <div class="github-link">Find an issue with this page? <a href="{{ .Site.Data.links.github_submit_fixes }}">Fix it on GitHub</a></div>
 
     <div class="copyright">
         <hr>


### PR DESCRIPTION
Continuing link.yaml fix,

Due to issue at footer.html when clicking on the link at the bottom of each page at the "Find an issue with this page? Fix it on GitHub" Link forwarded to a wierd URL.

changed the <a> tag to fix the link to submit a new issue in github

Accidently created two branches, patch1 and patch2,
combining both fixes the issue described above.