### PR TITLE
removed wrong prompt variable

### DIFF
--- a/hugo/content/lessons/windows-10-for-web-dev/index.md
+++ b/hugo/content/lessons/windows-10-for-web-dev/index.md
@@ -104,7 +104,6 @@ Here are some variables commonly used in the prompt
 - `\W` basename of the current working directory
 - `\h` hostname
 - `\u` username
-- `\t` full working directory
 - `\t` time 24-hour HH:MM:SS
 - `\T` time 12-hour HH:MM:SS
 - `\@` time 12-hour am/pm


### PR DESCRIPTION
There was a wrong "\t full working directory" in the "Customize the Command Line Prompt" section.