### PR TITLE
Added the icon for IOS PWA

### DIFF
--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -29,6 +29,7 @@
 
     <!-- PWA -->
     <link rel="shortcut icon" href="/img/favicon.png" type="image/x-icon">
+    <link rel="apple-touch-icon" type="image/x-icon" href="/img/favicon.png" />
     <meta name="theme-color" content="#454e56">
 
     <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
The reason for this small PR is that in IOS the app icon doesn't show correctly, but now it does

<img width="968" alt="Screen Shot 2020-06-09 at 10 29 08" src="https://user-images.githubusercontent.com/26267431/84167644-1e387e80-aa3c-11ea-8c84-1061271aad61.png">
