### PR TITLE
Fix problem with undefined variable on line 53

### DIFF
--- a/hugo/content/snippets/read-a-single-firestore-document.md
+++ b/hugo/content/snippets/read-a-single-firestore-document.md
@@ -50,7 +50,7 @@ async function getUserByEmail(email) {
   // Make the initial query
   const query = await db.collection('users').where('email', '==', email).get();
 
-   if (!result.empty) {
+   if (!query.empty) {
     const snapshot = query.docs[0];
     const data = snapshot.data();
   } else {


### PR DESCRIPTION
In **With a Unique Field** example, check for emptiness should be on `query` not `result`.