### PR TITLE
Android requires purchases to be acknowledged

### DIFF
--- a/hugo/content/lessons/flutter-inapp-purchases/index.md
+++ b/hugo/content/lessons/flutter-inapp-purchases/index.md
@@ -233,9 +233,13 @@ In the case of consumable products, you will also likely need to query your own 
         await _iap.queryPastPurchases();
 
     for (PurchaseDetails purchase in response.pastPurchases) {
-      if (Platform.isIOS) {
-        InAppPurchaseConnection.instance.completePurchase(purchase);
-      }
+      final pending = Platform.isIOS
+        ? purchaseDetails.pendingCompletePurchase
+        : !purchaseDetails.billingClientPurchase.isAcknowledged;
+
+        if (pending) {
+          InAppPurchaseConnection.instance.completePurchase(purchase);
+        }
     }
 
     setState(() {


### PR DESCRIPTION
Since the March 2020 Update to the plugin, Android requires that the plugin be updated. I had lost around 3 days worth of money because of this bug.

https://stackoverflow.com/questions/59754136/acknowledge-a-purchase-using-flutter