### PR TITLE
Add .dockerignore file and explanation

### DIFF
--- a/hugo/content/lessons/docker-basics-tutorial-nodejs/index.md
+++ b/hugo/content/lessons/docker-basics-tutorial-nodejs/index.md
@@ -46,6 +46,15 @@ EXPOSE 8080
 CMD [ "npm", "start" ]
 ```
 
+### Dockerignore
+
+A Dockerignore file is required so we don't add the node_modules folder to the image.
+
+{{< file "docker" ".dockerignore" >}}
+```docker
+node_modules
+```
+
 
 ### Node.js App
 


### PR DESCRIPTION
A .dockerignore file is required so we don't add the node_modules folder to the image.

This was included in the video, but I can not see it in the article.