### PR TITLE
Update user-google-signin-directive.md

### DIFF
--- a/hugo/content/courses/angular/user-google-signin-directive.md
+++ b/hugo/content/courses/angular/user-google-signin-directive.md
@@ -38,7 +38,7 @@ export class GoogleSigninDirective {
 
   @HostListener('click')
   onclick() {
-    this.afAuth.auth.signInWithPopup(new firebase.auth.GoogleAuthProvider());
+    this.afAuth.signInWithPopup(new firebase.auth.GoogleAuthProvider());
   }
 }
 
@@ -82,6 +82,6 @@ export class LoginPageComponent {
       Logged in as <strong>{{ user.email }}</strong>
     </p>
 
-    <button mat-stroked-button (click)="afAuth.auth.signOut()">Logout</button>
+    <button mat-stroked-button (click)="afAuth.signOut()">Logout</button>
   </div>
 {{< /highlight >}}


### PR DESCRIPTION
Does not have auth after afAuth anymore. I was having trouble getting it to work and it was because of this.
afAuth.auth.signInWithPopup -> afAuth.signInWithPopup same with sign out in html