### PR TITLE
Fix css

### DIFF
--- a/hugo/content/lessons/css-cards-animated/index.md
+++ b/hugo/content/lessons/css-cards-animated/index.md
@@ -203,7 +203,7 @@ A gradient text background cannot be applied with the `color` property. Instead,
 }
 
 .card-header h2 {
-    font-size: 20px;s
+    font-size: 20px;
     margin: .25rem 0 auto;
     cursor: pointer;
 }


### PR DESCRIPTION
The rule for card-header h2 has a s following the semicolon on font-size
Before:
.card-header h2 {
    font-size: 20px;s
   ...
}
After:
.card-header h2 {
    font-size: 20px;
  ...
}