### PR TITLE
Remove redundant malformed code snippet

### DIFF
--- a/hugo/content/lessons/testing-cloud-functions-in-firebase/index.md
+++ b/hugo/content/lessons/testing-cloud-functions-in-firebase/index.md
@@ -208,16 +208,6 @@ export const createUserRecord = functions.auth
 
 The auth function is tested in the same manner as Firestore. In fact, all background functions (Firestore, RTDB, Auth, Storage, PubSub) follow similar testing patterns. Notice how we use `testEnv.auth.makeUserRecord(...)`. This allows us to generate a fake user record specifically for this test with the values we specify.
 
-<div class="pro-anchor2">
-```typescript
-describe('createUserRecord', () => {
-
-  // ... pro only
-
-})
-```
-</div>
-
 <div class="pro-only2">
 
 ```typescript


### PR DESCRIPTION
Fixes malformed code snippet towards the bottom of this page: https://fireship.io/lessons/testing-cloud-functions-in-firebase/

Search for: `typescript describe` to find it