### PR TITLE
Fixed missing tag

### DIFF
--- a/hugo/content/lessons/web-scraping-guide/index.md
+++ b/hugo/content/lessons/web-scraping-guide/index.md
@@ -10,6 +10,7 @@ tags:
     - firebase
     - cloud-functions
     - puppeteer
+    - mvp
 
 youtube: dXjKh66BR2U 
 github: https://github.com/fireship-io/198-web-scraper-link-preview


### PR DESCRIPTION
The Modern Web Scraping Guide is the part of the Minimum Viable Product series, so I added it in the tags.