### PR TITLE
Update firestore-emulator-flutter.md

### DIFF
--- a/hugo/content/snippets/firestore-emulator-flutter.md
+++ b/hugo/content/snippets/firestore-emulator-flutter.md
@@ -57,11 +57,7 @@ class _MyHomePageState extends State<MyHomePage> {
   void initState() {
     String host = Platform.isAndroid ? '10.0.2.2:8080' : 'localhost:8080';
 
-    Firestore.instance.settings(
-      host: host,
-      sslEnabled: false,
-      persistenceEnabled: false,
-    );
+    FirebaseFirestore.instance.settings = Settings(host: host, sslEnabled: false);
 
 
     super.initState();


### PR DESCRIPTION
Based on the latest update to flutter, the old code doesn't work to connect the flutter app to Firestore Emulator. This is new that works well as specified [here](https://firebase.flutter.dev/docs/firestore/usage/#emulator-usage).