### PR TITLE
Make top nav flush with top of screen

### DIFF
--- a/design/scss/nav.scss
+++ b/design/scss/nav.scss
@@ -129,7 +129,7 @@ a.item {
   position: fixed;
   top: 0;
   right: 0; //var(--nav-width);
-  margin: 0.5em 1.5em;
+  margin: 0em 1.5em 0.5em 1.5em;
   display: flex;
   flex-direction: row;
   justify-content: space-between;


### PR DESCRIPTION
Top nav does not sit flush with the top of the window, changing top margin to 0 fixes this issue.