### PR TITLE
Correct invalid variable in testing-rxjs-observables-with-jest.md

### DIFF
--- a/hugo/content/snippets/testing-rxjs-observables-with-jest.md
+++ b/hugo/content/snippets/testing-rxjs-observables-with-jest.md
@@ -33,7 +33,7 @@ You can then write your expectations inside of the the subscribe callback, then 
 import { of } from 'rxjs';
 
 test('the observable emits hello', done => {
-  of('hello').subscribe( str => {
+  of('hello').subscribe( data => {
     expect(data).toBe('hola');
     done();
   });


### PR DESCRIPTION
- `data` will be an undefined variable used in the test assertion currently.
- Replace `str` with `data` inside subscribe next block to correct