### PR TITLE
fix: typos in NextJS course

### DIFF
--- a/hugo/content/courses/react-next-firebase/admin-auth-guard.md
+++ b/hugo/content/courses/react-next-firebase/admin-auth-guard.md
@@ -28,7 +28,7 @@ export default function AuthCheck(props) {
 
 ## Usage in a Component
 
-{{< file "js" "admin/index.js.js" >}}
+{{< file "js" "admin/index.js" >}}
 ```javascript
 import AuthCheck from '../../components/AuthCheck';
 

--- a/hugo/content/courses/react-next-firebase/ssr-profile-page.md
+++ b/hugo/content/courses/react-next-firebase/ssr-profile-page.md
@@ -98,7 +98,7 @@ export default function UserProfilePage({ user, posts }) {
 
 ## Post Feed
 
-[UserProfile Code](https://github.com/fireship-io/next-firebase-course/blob/main/components/PostFeed.js)
+[PostFeed Code](https://github.com/fireship-io/next-firebase-course/blob/main/components/PostFeed.js)
 
 
 {{< file "js" "components/PostFeed.js" >}}


### PR DESCRIPTION
1. `hugo/content/courses/react-next-firebase/ssr-profile-page.md:101`
UserProfile was duplicated, it should be `PostFeed`.

2. `admin-auth-guard.md:31`
It should be `admin/index.js` instead of `admin/index.js.js`.