### PR TITLE
`destroyed` lifecycle hook is deprecated

### DIFF
--- a/hugo/content/courses/vue/auth-state.md
+++ b/hugo/content/courses/vue/auth-state.md
@@ -53,7 +53,7 @@ export default {
     }
   },
 
-  destroyed() {
+  unmounted() {
     this.unsubscribe()
   }
 }


### PR DESCRIPTION
```bash
error  The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead  vue/no-deprecated-destroyed-lifecycle
```