### PR TITLE
Update http-basic.md

### DIFF
--- a/hugo/content/courses/cloud-functions/http-basic.md
+++ b/hugo/content/courses/cloud-functions/http-basic.md
@@ -18,6 +18,7 @@ export const basicHTTP = functions.https.onRequest((request, response) => {
 
   if (!name) {
     response.status(400).send('ERROR you must supply a name :(');
+    return;
   }
 
   response.send(`hello ${name}`);


### PR DESCRIPTION
For me, without the return; I got this error:

✔  functions: Using node@10 from host.
i  functions: Watching "/Users/eric/Documents/my-workspace/Fireship/cloud-functions/functions" for Cloud Functions...
✔  functions[basicHTTP]: http function initialized (http://localhost:5000/ninja-cloud-functions-c5b0a/us-central1/basicHTTP).
i  functions: Beginning execution of "basicHTTP"
⚠  functions: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:470:11)
    at ServerResponse.header (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/response.js:771:10)
    at ServerResponse.send (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/response.js:170:12)
    at exports.basicHTTP.functions.https.onRequest (/Users/eric/Documents/my-workspace/Fireship/cloud-functions/functions/lib/http.js:13:10)
    at runFunction (/usr/local/lib/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:600:16)
    at runFunction (/usr/local/lib/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:579:15)
    at runHTTPS (/usr/local/lib/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:599:11)
    at handler (/usr/local/lib/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:528:23)
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:137:13)

I guess, because he was not returning after the if and tried to send, when the response was already gone. Which made my server crash.