### PR TITLE
Update nextjs-ssr-data-fetching-with-firebase.md

### DIFF
--- a/hugo/content/snippets/nextjs-ssr-data-fetching-with-firebase.md
+++ b/hugo/content/snippets/nextjs-ssr-data-fetching-with-firebase.md
@@ -81,6 +81,8 @@ The code above uses the nullish coalescing operator `??` to fallback to props, b
 
 {{< file "react" "custom-hook.js" >}}
 ```jsx
+import { useDocumentData } from 'react-firebase-hooks/firestore'
+
 function useDocumentDataSSR(ref, options) {
   const [value, loading, error] = useDocumentData(ref, options)
 
@@ -97,8 +99,6 @@ Now access fields on the Firestore document without worrying about whether it ca
 
 {{< file "react" "some-page.js" >}}
 ```jsx
-import { useDocumentData } from 'react-firebase-hooks/firestore'
-
 export default function SomePage(props) {
 
   const ref = firestore.doc('items/foo')


### PR DESCRIPTION
I moved an import statement that I believe in having been misplaced.
`useDocumentData` is used in the `custom-hook.js` file snippet but without any import.
The `some-page.js` file snippet had the `useDocumentData` imported.

To make the usage a little clearer, I suggest swapping the import between the two snippets.