### PR TITLE
increase video width to 100%

### DIFF
--- a/design/scss/content.scss
+++ b/design/scss/content.scss
@@ -347,7 +347,7 @@
 
 .vid-center {
   margin: 0 auto;
-  max-width: 75%;
+  max-width: 100%;
 }
 
 video,


### PR DESCRIPTION
When viewing split-screen the video's code is unreadable due to this setting.  See before and after pictures.

![before](https://user-images.githubusercontent.com/3054831/124181047-a429cc00-da7a-11eb-95bc-9cdcb4a4dcd3.png)
![after](https://user-images.githubusercontent.com/3054831/124181036-a1c77200-da7a-11eb-9592-fe13ebf6a47b.png)
