### PR TITLE
Corrected reference to non-existent file in Svelte-Electron tutorial (svelte-electron-setup.md)

### DIFF
--- a/hugo/content/snippets/svelte-electron-setup.md
+++ b/hugo/content/snippets/svelte-electron-setup.md
@@ -81,7 +81,7 @@ Make the following changes to the rollup config file. Update the serve function 
 {{< file "rollup" "rollup.config.json" >}}
 ```js
 export default {
-	input: 'src/svelte.js',  // <-- here
+	input: 'src/main.js',  // <-- here
     // ...omitted
 }
 


### PR DESCRIPTION
Fixing reference to a file name which doesn't exist in the svelte-electron tutorial
- Readers are instructed to copy the file "main.js" from the template, we either add a "rename that file to 'svelte.js'" instruction or we make this correction.