### PR TITLE
Update delete-firestore-collection.md

### DIFF
--- a/hugo/content/snippets/delete-firestore-collection.md
+++ b/hugo/content/snippets/delete-firestore-collection.md
@@ -40,12 +40,12 @@ First, obtain CI token to authenticate firebase tools.
 
 ```shell
 cd functions
-npm i firebase-tools -D
+npm i firebase-tools
 
 firebase login:ci
 # your_token
 
-firebase functions:config:set ci_token="your_token"
+firebase functions:config:set fb.token="your_token"
 ```
 
 The function should validate the user has permission to run the operation. If allowed, it runs the CLI command recursively on the collection and its nested subcollections. 


### PR DESCRIPTION
Hey Jeff,

Just made some small fixes to this blog post; as it seems to be have changed since you made it.

`ci_token` is not a valid argument anymore, see the recommended steps in the README below
https://github.com/firebase/snippets-node/tree/master/firestore/solution-deletes

Also removed the `-D` flag from the package installation to avoid the error when deploying:
`Error: Cannot find module 'firebase-tools'`

Cheers