### PR TITLE
Add user/username to <UserContext.Provider>

### DIFF
--- a/hugo/content/courses/react-next-firebase/auth-context.md
+++ b/hugo/content/courses/react-next-firebase/auth-context.md
@@ -30,7 +30,7 @@ import { UserContext } from '../lib/context';
 function MyApp({ Component, pageProps }) {
   
   return (
-    <UserContext.Provider>
+    <UserContext.Provider value={{ user: {}, username: 'jeff' }}>
       <Navbar />
       <Component {...pageProps} />
       <Toaster />


### PR DESCRIPTION
A friendly nitpick:  The current .md file is missing the "value" attribute for <UserContext.Provider>. This proposed edit is to match the code from the video @ 1:55.

(Without this attribute, the code breaks. See the question from Neal in the page comments.)