### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git clone <your-forked-repo>
 npm install
 npm run dev
 
-git checkout -b my-fix
+git switch -c my-fix
 # fix some code...
 
 git commit -m "fix: corrected a typo"


### PR DESCRIPTION
`git checkout -b <new-branch>` is outdated and `git switch -c <new-branch>` was added as an alternative from Git v2.23.