### PR TITLE
Fix gradient text unreadable on selection

### DIFF
--- a/design/scss/util.scss
+++ b/design/scss/util.scss
@@ -253,5 +253,9 @@ text-cycle {
   -webkit-background-clip: text;
   color: transparent;
   -webkit-text-fill-color: transparent;
+  
+  &::selection {
+    -webkit-text-fill-color: var(--h-color);
+  }
 }
 


### PR DESCRIPTION
At the time, when selecting text with a gradient color, the text becomes unreadable. This is caused by the way browsers interpret `-webkit-background-clip: text;` on `::selection`. This issue can be fixed by explicitly overwriting `-webkit-text-fill-color` to be a real color.