### PR TITLE
Fix: Github to GitHub in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Edit and fix the site's content in `hugo/content/`. Feel free to submit PRs for 
 
 ### Option 1 - Simple Typo Fixes
 
-For small issues, like a typo or broken link, use Github's inline file editor to make the fix and submit a pull request. 
+For small issues, like a typo or broken link, use GitHub's inline file editor to make the fix and submit a pull request. 
 
 ### Option 2 - Work on your own Fork
 
 For more complex contributions, like guest posts and new features, you should work on the project on your local system. 
 
-First, fork this repo on Github.
+First, fork this repo on GitHub.
 
 ```shell
 git clone <your-forked-repo>
@@ -40,7 +40,7 @@ git commit -m "fix: corrected a typo"
 git push origin my-fix
 ```
 
-Lastly, open a pull request on Github. Once merged, your changes will automatically be deployed to the live site via the CI/CD pipeline. 
+Lastly, open a pull request on GitHub. Once merged, your changes will automatically be deployed to the live site via the CI/CD pipeline. 
 
 ## Running the Site
 


### PR DESCRIPTION
Changed Github to GitHub throughout the README.md

See - https://docs.github.com/en for correct capitalization.