### PR TITLE
Make npm dev script fail if hugo not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "cypress open",
     "dev:design": "webpack --watch",
     "dev:hugo": "cd hugo && hugo server --disableFastRender",
-    "dev": "concurrently \"npm run dev:hugo\" \"npm run dev:design\"",
+    "dev": "concurrently \"npm run dev:hugo\" \"npm run dev:design\" --kill-others-on-fail",
     "build:design": "webpack",
     "build:hugo": "cd hugo && hugo",
     "build:components": "cd components && npm run build",


### PR DESCRIPTION
`npm run dev:hugo` fails with exit code 1 if hugo is not installed locally

Add a flag `--kill-others-on-fail` of `concurrently` to kill all processes if one of them fails. This will kill webpack dev server when `dev:hugo` fails

This resolves #511 