### PR TITLE
Fixed typos in CODE OF CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ If a community member engages in unacceptable behavior, the community organizers
 
 ## 7. Reporting Guidelines
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. https://twitter.com/fireship_dev/.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. https://twitter.com/fireship_dev/
 
 [Reporting guidelines](https://fireship.io/terms/)
 
@@ -67,11 +67,9 @@ Additionally, community organizers are available to help community members engag
 
 If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify fireship-io with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies. [Policy](https://fireship.io/privacy-policy/)
 
-
-
 ## 9. Scope
 
-We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues--online and in-person--as well as in all one-on-one communications pertaining to community business.
+We expect all community participants (contributors paid or otherwise, sponsors, and other guests) to abide by this Code of Conduct in all community venues--online and in-person--as well as in all one-on-one communications pertaining to community business.
 
 This code of conduct and its related procedures also applies to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
 


### PR DESCRIPTION
Deleted a period on line 60 after the URL and replaced some semicolons with commas on line 72