### PR TITLE
Updated z-index of #carbonads

### DIFF
--- a/design/scss/ads.scss
+++ b/design/scss/ads.scss
@@ -1,5 +1,6 @@
 #carbonads {
     font-family: var(--font-body);
+    z-index: 101;
   }
   
   


### PR DESCRIPTION
Paypal link when you click `enroll for $xx` partly hides carbon ad. Fixed it by updating the z-index of the ad to 101.

![image](https://user-images.githubusercontent.com/82570809/150916593-2c3c46ca-ffc7-4ebb-a61b-321c13203b4a.png)
