### PR TITLE
Added dash and fullstop for readability

### DIFF
--- a/hugo/content/about.md
+++ b/hugo/content/about.md
@@ -37,11 +37,11 @@ We provide support through various services in addition to content production.
 With JavaScript of course. More specifically, the UI mostly relies on Web
 Components via Angular Elements. User auth and all backend cloud resources
 are handled by Firebase. The static HTML and content is managed with Hugo
-- it's the JAM Stack on steroids.
+— it's the JAM Stack on steroids.
 
 ### What Tools do you Use?
 
-- **Code** with VS Code. [Fira Code](https://github.com/tonsky/FiraCode) font and [vscode-icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
+- **Code** with VS Code. [Fira Code](https://github.com/tonsky/FiraCode) font and [vscode-icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons).
 - **Video Production** with Adobe Premiere. 
 - **Graphics** with Figma and AfterEffects.
 


### PR DESCRIPTION
The dash after "Hugo" improves readability by amplifying the following statement. 
The fullstop was missing in the first bulletin of the last paragraph