### PR TITLE
fix: link

### DIFF
--- a/hugo/content/snippets/algolia-instantsearch-angular.md
+++ b/hugo/content/snippets/algolia-instantsearch-angular.md
@@ -23,7 +23,7 @@ type: lessons
 ---
 
 {{< box emoji="👀" >}}
-This tutorial is an extension of the [Algolia Cloud Functions Guide](/lessons/algolia-cloud-functions/). You must have the Cloud Functions deployed to start making instant search queries from your frontend app. 
+This tutorial is an extension of the <a href="/lessons/algolia-cloud-functions/">Algolia Cloud Functions Guide</a>. You must have the Cloud Functions deployed to start making instant search queries from your frontend app.
 {{< /box >}}
 
 ## Install Instantsearch


### PR DESCRIPTION
@codediodeio This happens a lot with markdown links in boxes. Is there something we could change to make markdown style links work in boxes?