### PR TITLE
Fixing "generateAPIKey()" logic

### DIFF
--- a/hugo/content/lessons/api-monetization-stripe/index.md
+++ b/hugo/content/lessons/api-monetization-stripe/index.md
@@ -124,7 +124,7 @@ function generateAPIKey() {
 
   // Ensure API key is unique
   if (apiKeys[hashedAPIKey]) {
-    generateAPIKey();
+    return generateAPIKey();
   } else {
     return { hashedAPIKey, apiKey };
   }


### PR DESCRIPTION
As a recursive function it needs to have a return if the API key already exists, otherwise it will not return the keys.