### PR TITLE
fixed the many typos in firebase-performance-quickstart lesson

### DIFF
--- a/hugo/content/lessons/firebase-performance-quickstart/index.md
+++ b/hugo/content/lessons/firebase-performance-quickstart/index.md
@@ -26,7 +26,7 @@ Firebase [announced Performance Monitoring](https://firebase.googleblog.com/2019
 
 ## Initial Setup
 
-The following demo uses Angular, but the principles apply to any frontend JavaScript web app - checkout the [official guide](https://firebase.google.com/docs/perf-mon/get-started-web) for setup instructions in non-Angular projects. By simplying including the performance package in your app you will receive metrics related to page load and HTTP performance. 
+The following demo uses Angular, but the principles apply to any frontend JavaScript web app - checkout the [official guide](https://firebase.google.com/docs/perf-mon/get-started-web) for setup instructions in non-Angular projects. By simply including the performance package in your app you will receive metrics related to page load and HTTP performance. 
 
 {{< box icon="scroll" class="box-blue" >}}
 Keep in mind, you can use Firebase Performance as a standalone service without any other Firebase dependencies. In this case, you would want to load the lightweight script via the CDN as described in docs.  
@@ -82,7 +82,7 @@ Just sit back and relax. Firebase will automatically collect the same page load 
 
 ## User Login
 
-A common use-case for a custom trace is your user authentication flow. Failing to get a user logged in or signed up quickly is a good recipe to bounce them forever. 
+A common use case for a custom trace is your user authentication flow. Failing to get a user logged in or signed up quickly is a good recipe to bounce them forever. 
 
 {{< box icon="scroll" class="box-blue" >}}
 #### What is the difference between an Attribute and a Metric?
@@ -94,7 +94,7 @@ An attribute is a string value segments data on the Firebase console. A metric i
 
 ### Trace Login Time
 
-For example, **How long does it take the average user to get logged in?**. But we don't have to stop there - we can also add custom attributes to segmenent reports based on custom data attributes and trace specific errors that happen during the login process. 
+For example, **How long does it take the average user to get logged in?**. But we don't have to stop there - we can also add custom attributes to segment reports based on custom data attributes and trace specific errors that happen during the login process. 
 
 {{< file "ngts" "login.component.ts" >}}
 {{< highlight typescript >}}
@@ -134,7 +134,7 @@ export class LoginComponent {
 
 ### Trace Lifecycle Hooks
 
-On iOS and Android, Firebase runs a screen trace to measure the lifetime of a screen detect frozen screens. You can use lifecycle hooks in your preferred framework to get similar results on the web. Here's how we can archive this in Angular:
+On iOS and Android, Firebase runs a screen trace to measure the lifetime of a screen to detect frozen screens. You can use lifecycle hooks in your preferred framework to get similar results on the web. Here's how we can archive this in Angular:
 
 {{< file "ngts" "login.component.ts" >}}
 {{< highlight typescript >}}
@@ -155,7 +155,7 @@ export class LoginComponent implements OnInit, OnDestroy {
 
 ## Firestore
 
-Firebase Perf can also be very useful when it comes understanding database performance. 
+Firebase Perf can also be very useful when it comes to understanding database performance. 
 
 ### Trace Read Latency and Quantity
 


### PR DESCRIPTION
simplying -> **simply**

use-case -> **use case** (better fits context)

segmenent -> **segment**

to measure the lifetime of a screen detect frozen screens -> to measure the lifetime of a screen **to** detect frozen screen

can also be very useful when it comes understanding -> can also be very useful when it comes **to** understanding