### PR TITLE
mint to buyer's address rather than the contract address

### DIFF
--- a/hugo/content/lessons/web3-solidity-hardhat-react-tutorial/index.md
+++ b/hugo/content/lessons/web3-solidity-hardhat-react-tutorial/index.md
@@ -369,9 +369,7 @@ function NFTImage({ tokenId, getCount }) {
   };
 
   const mintToken = async () => {
-    const connection = contract.connect(signer);
-    const addr = connection.address;
-    const result = await contract.payToMint(addr, metadataURI, {
+    const result = await contract.payToMint(accounts[0], metadataURI, {
       value: ethers.utils.parseEther('0.05'),
     });
 


### PR DESCRIPTION
"addr" returns the contract address,must be changed to the current address.