### PR TITLE
fix: added .code-workpace files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ hugo/static/design
 .vscode
 *.launch
 *.sublime-workspace
+*.code-workspace
 
 # misc
 .env


### PR DESCRIPTION
don't want to muddy up the repo with code-workspace files. Already has exception for sublime-workspace files so figured it fit.