### PR TITLE
fix: Missing Code

### DIFF
--- a/hugo/content/courses/vue/firestore-messages-query.md
+++ b/hugo/content/courses/vue/firestore-messages-query.md
@@ -87,6 +87,8 @@ export default {
               createdAt: Date.now(),
 
           });
+          this.loading = false;
+          this.newMessageText = "";
       }
     },
 };


### PR DESCRIPTION
The Vue/Firebase tutorial has missing code inside of the tutorial markdown even though the code is shown in the video, and is required for the code to function correctly. This fix adds the missing code.