### PR TITLE
fix: missing return in recursive fn

### DIFF
--- a/hugo/content/lessons/api-monetization-stripe/index.md
+++ b/hugo/content/lessons/api-monetization-stripe/index.md
@@ -124,7 +124,7 @@ function generateAPIKey() {
 
   // Ensure API key is unique
   if (apiKeys[hashedAPIKey]) {
-    generateAPIKey();
+    return generateAPIKey();
   } else {
     return { hashedAPIKey, apiKey };
   }


### PR DESCRIPTION
this caught my eye on the video. If the hash is repeated (incredibly unlikely) this recursive function would return undefined. Fixed by returning the value of the recursive call.