### PR TITLE
fixed typo in heart-create.md

### DIFF
--- a/hugo/content/courses/react-next-firebase/hearts-create.md
+++ b/hugo/content/courses/react-next-firebase/hearts-create.md
@@ -44,7 +44,7 @@ export default function Heart({ postRef }) {
     await batch.commit();
   };
 
-  return heartDoc?.exists ? (
+  return heartDoc?.exists() ? (
     <button onClick={removeHeart}>💔 Unheart</button>
   ) : (
     <button onClick={addHeart}>💗 Heart</button>


### PR DESCRIPTION
in the Next.js/Firebase course, doc.exists is called as a property but is actually a method. so the following expression below always defaults to true since the exists method is not null or undefined. i was having a bug on my course where I could unheart a post an infinite number of times 💔😭.

```js
 return heartDoc?.exists ? (
    <button onClick={removeHeart}>💔 Unheart</button>
  ) : (
    <button onClick={addHeart}>💗 Heart</button>
  );
```

i updated the doc to add the exists() method, i also tested this on my own repo and now i can re-heart all my unhearted posts 🥰

```js
 return heartDoc?.exists() ? (
    <button onClick={removeHeart}>💔 Unheart</button>
  ) : (
    <button onClick={addHeart}>💗 Heart</button>
  );
```

hugo/content/courses/react-next-firebase/hearts-create.md