### PR TITLE
Fixes for code this not that python

### DIFF
--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -91,6 +91,9 @@ One way to do this is to define a list, and use a <code>for</code> loop to itera
 
 Python provides a neat one-liner for this purpose, called a "list comprehension". To write a list comprehension, start with the expression you would normally pass to the <code>append</code> method. From there, write the <code>for</code> loop condition immediately after the initial expression. Lastly, put everything inside a pair of square brackets. Comprehensions can be used with dictionaries, sets, and generators, however, try to avoid them with complex expressions. Readability is key.
 
+When making your code more dense, be careful not to make it less readable. More complex logic may be more readable with a full loop.
+[At Google, they never allow nested list comprehensions.](https://google.github.io/styleguide/pyguide.html#274-decision)
+
 {{< file "python" "list_comprehension.py" >}}
 {{< highlight "python" >}}
 # OK version 🤔 - For loop and append ❌ 

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -68,7 +68,9 @@ if num_comments is not None: # Could be 0
 
 
 ## Included values
-In this section, we need to check if a list <code>(languages)</code> contains the value of a particular variable <code>(my_language)</code>.
+In this section, we need to check if a list (<code>languages</code>) 
+contains the value of a particular variable (<code>my_language</code>).
+
 One way to do this is by using a <code>for</code> loop to iterate over all elements and check for equality. 
 Python provides a nice shortcut, using the <code>in</code> keyword.
 
@@ -92,7 +94,10 @@ if my_language in languages:
 ## List Comprehensions
 A common data processing pattern is to define an empty list and append values to it.
 For example, let's assume we want to generate a list of square numbers in a certain range.
-One way to do this is to define a list, and use a <code>for</code> loop to iterate over a range of values and append each value to the list.
+One way to do this is to define a list, use a <code>for</code> loop to iterate over a range of values,
+and append results to the list.
+
+Python provides a neat one-liner for this purpose, called a "list comprehension". 
 
 Python provides a neat one-liner for this purpose, called a "list comprehension". To write a list comprehension, start with the expression you would normally pass to the <code>append</code> method. From there, write the <code>for</code> loop condition immediately after the initial expression. Lastly, put everything inside a pair of square brackets. Comprehensions can be used with dictionaries, sets, and generators, however, try to avoid them with complex expressions. Readability is key.
 
@@ -140,8 +145,8 @@ contains_neg = any(num < 0 for num in nums) # True
 contains_neg = not all(num >= 0 for num in nums) # True
 {{< /highlight >}}
 
- - <code>any</code> - Returns True if a condition applies to any element of the iterable. If the iterable is empty, returns False. 
- - <code>all</code> - Returns True if a condition applies to  all elements of the iterable (or if the iterable is empty).
+ - <code>any</code> - Returns True if a condition applies to _any_ element of the iterable. Returns <code>False</code> when empty.
+ - <code>all</code> - Returns True if a condition applies to _all_ elements of the iterable. Returns <code>True</code> when empty.
   
 ## Iterations
 
@@ -283,8 +288,14 @@ my_numbers_2 = better_append(42) # [42]
 {{< /highlight >}}
 
 ## Context Managers
-The last tip is to use a context manager to ensure that a resource is properly closed. Let's consider a simple example of writing to a text file.
-In this case, the simple code will run just fine, however, if more complex logic is involved and an exception is raised during the write, the file won't be closed. Another common scenario is simply to forget to close the file. Using a context manager ensures the file will always be closed, regardless of any exception.
+The last tip is to use a context manager to ensure that a resource is properly closed. 
+Let's consider a simple example of writing to a text file.
+
+The simple code will run just fine, but if more complex logic is involved and an exception is raised during the <code>file.write</code>, 
+the file won't be closed. 
+It is also easy to forget to close the file. 
+
+Using a context manager ensures the file will always be closed, regardless of any exception.
 
 {{< file "python" "context_managers.py" >}}
 {{< highlight "python" >}}

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -64,17 +64,17 @@ One way to do this is by using a <code>for</code> loop to iterate over all eleme
 {{< file "python" "contains.py" >}}
 {{< highlight "python" >}}
 # Check if a value is contained in a list
-L = ["JavaScript", "Python", "Ruby", "PHP", "Rust"]
-x = "Rust"
+langauges = ["JavaScript", "Python", "Ruby", "PHP", "Rust"]
+my_language = "Rust"
 
 # OK version 🤔 - For loop and a equality check ❌
-for i in range(len(L)):
-    if x == L[i]:
-        print(f"{x} is contained in the list")
+for i in range(len(languages)):
+    if my_language == languages[i]:
+        print(f"{my_language} is contained in the list")
 
 # Pythonic version 🐍: Use "if x in L" ✅
-if x in L:
-    print(f"{x} is contained in the list")
+if my_language in languages:
+    print(f"{my_language} is contained in the list")
 {{< /highlight >}}
 
 
@@ -138,20 +138,20 @@ Python provides a nice syntax for iteration that many users tend to ignore. For 
 {{< file "python" "iterations.py" >}}
 {{< highlight "python" >}}
 # Iterating over a single list
-L = ["a", "b", "c", "d"]
+letters = ["a", "b", "c", "d"]
 
 # OK version 🤔 - Index in range ❌ 
-for i in range(len(L)):
-    val = L[i]
-    print(i, val)
+for i in range(len(letters)):
+    letter = letters[i]
+    print(i, letter)
 
 # Pythonic version 🐍: Access elements directly ✅
-for el in L:
-    print(el)
+for letter in letters:
+    print(letter)
 
 # Pythonic version 🐍: Use enumerate if you need the index, value pair ✅
-for i, val in enumerate(L):
-    print(i, val)
+for i, letter in enumerate(letters):
+    print(i, letter)
 {{< /highlight >}}
 
 💡 _Bonus Tip_: These ideas also apply when iterating over multiple lists. We can iterate directly over values in two collections
@@ -160,21 +160,21 @@ using <code>zip</code>. If an index is required, we can use a combination of <co
 {{< file "python" "iterations.py" >}}
 {{< highlight "python" >}}
 # Bonus Tip 💡:  Iterating over multiple lists
-A = ["a", "b", "c", "d"]
-B = ["e", "f", "g", "h"]
+traits = ["big", "salty", "scary"]
+animals = ["cat", "oyster", "crocodile"]
 
 # OK version 🤔 - Index in range ❌ 
 for i in range(len(A)):
-    va, vb = A[i], B[i]
-    print(i, va, vb)
+    trait, animal = traits[i], animals[i]
+    print(i, trait, animal)
 
 # Pythonic version 🐍: Use zip to get the values ✅
-for va, vb in zip(A, B):
-    print(va, vb)
+for trait, animal in zip(traits, animals):
+    print(trait, animal)
 
 # Pythonic version 🐍: Use a combination of zip and enumerate to get the index and the values ✅
-for i, (va, vb) in enumerate(zip(A, B)):
-    print(i, va, vb)
+for i, (trait, animal) in enumerate(zip(traits, animals)):
+    print(i, trait, animal)
 {{< /highlight >}}
 
 ## Tuple Unpacking
@@ -202,16 +202,16 @@ Python uses <code>if/elif/else</code> blocks for control flow. For example, cons
 {{< file "python" "ternary_operator.py" >}}
 {{< highlight "python" >}}
 # Assign a value based on a condition
-a = 42
+score = 42
 
 # OK version 🤔 - if/else blocks ❌ 
-if a > 0:
+if score > 0:
     sign = "positive"
 else:
     sign = "negative"
 
 # Pythonic way 🐍 - Use a ternary operator ✅
-sign = "positive" if (a > 0) else "negative" # parentheses are optional
+sign = "positive" if (score > 0) else "negative" # parentheses are optional
 {{< /highlight >}}
 
 ## Generators
@@ -222,14 +222,14 @@ sign = "positive" if (a > 0) else "negative" # parentheses are optional
 from sys import getsizeof 
 
 # Inefficent way 💩: Using a list ❌
-L = [n for n in range(42_000)]
-sum(L) # 881979000
-getsizeof(L) # 351064 bytes
+numbers_list = [n for n in range(42_000)]
+sum(numbers_list) # 881979000
+getsizeof(numbers_list) # 351064 bytes
 
 # Efficient way 🔥: Use a generator ✅
-G = (n for n in range(42_000))
-sum(G) # 881979000 bytes
-getsizeof(G) # 112 bytes
+numbers_generator = (num for num in range(42_000))
+sum(numbers_generator) # 881979000
+getsizeof(numbers_generator) # 112 bytes
 {{< /highlight >}}
 
 ## Mutable Default Arguments
@@ -238,23 +238,23 @@ Python supports default values for function parameters. If a value for a paramet
 {{< file "python" "mutable_default_args.py" >}}
 {{< highlight "python" >}}
 # Mutable default arguments 💩:  Wrong way  ❌
-def append_element(elem, L=[]):
-    L.append(elem)
-    return L
+def append_element(elem, previous_list=[]):
+    previous_list.append(elem)
+    return previous_list
 
-L1 = append_element(21) # [21]
-L2 = append_element(42) # [21, 42] - Oops..
+my_numbers_1 = append_element(21) # [21]
+my_numbers_2 = append_element(42) # [21, 42] - Oops..
 
 
 # Correct way 🔥: Use None ✅
-def better_append(elem, L=None):
-    if L is None:
-        L = []
-    L.append(elem)
-    return L
+def better_append(elem, previous_list=None):
+    if previous_list is None:
+        previous_list = []
+    previous_list.append(elem)
+    return previous_list
 
-L1 = better_append(21) # [21]
-L2 = better_append(42) # [42]
+my_numbers_1 = better_append(21) # [21]
+my_numbers_2 = better_append(42) # [42]
 
 {{< /highlight >}}
 
@@ -265,11 +265,11 @@ In this case, the simple code will run just fine, however, if more complex logic
 {{< file "python" "context_managers.py" >}}
 {{< highlight "python" >}}
 # Managing files - using open and f.close() ❌
-f = open("file.txt", "w")
-f.write("Hi mom!") 
-f.close()
+file = open("file.txt", "w")
+file.write("Hi mom!") 
+file.close()
 
 # Pythonic way 🐍 -  Use a context manager ✅
-with open("file.txt", "w") as f:
-    f.write("Hi mom!") 
+with open("file.txt", "w") as file:
+    file.write("Hi mom!") 
 {{< /highlight >}}

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -50,13 +50,15 @@ Python will format the result into a string containing the variables.
 
 {{< file "python" "null_checks.py" >}}
 {{< highlight "python" >}}
+user = get_user() # user could be a truthy user object, or None
+
 # OK version 🤔: Unnecessary explicit check  
-if user is not None: # user is an object, always truthy if not None
+if user is not None: 
     print(f"user exists and equals {user}")
 # This is okay if it makes the code safer or more readable.
 
 # Pythonic version 🐍: Shorten when safe ✅
-if user: # user is an object, always truthy if not None
+if user:
     print(f"user exists and equals {user}")
 
 # Pythonic version 🐍: Use specific guard if the value could be falsey when not None ✅

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -43,7 +43,10 @@ Be careful if some falsey values should be treated differently in the logic,
 like if you want to reject <code>None</code> but accept <code>0</code> or <code>""</code>. 
 In these cases, specifying <code>if some_var is not None:</code> is necessary.
 
-💡 _Bonus Tip_: Use <code>f-strings</code> for string formatting. Initiate an f-string by typing an _f_ immediately before a regular string <code>(f"...")</code>, and place variables inside curly braces. Python will format the result into a string containing the variables.
+💡 _Bonus Tip_: Use <code>f-strings</code> for string formatting. 
+Initiate an f-string by typing an _f_ immediately before a regular string and place variables inside curly braces, 
+like <code>(f"My variable is {my_var}")</code>. 
+Python will format the result into a string containing the variables.
 
 {{< file "python" "null_checks.py" >}}
 {{< highlight "python" >}}

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -99,10 +99,19 @@ and append results to the list.
 
 Python provides a neat one-liner for this purpose, called a "list comprehension". 
 
-Python provides a neat one-liner for this purpose, called a "list comprehension". To write a list comprehension, start with the expression you would normally pass to the <code>append</code> method. From there, write the <code>for</code> loop condition immediately after the initial expression. Lastly, put everything inside a pair of square brackets. Comprehensions can be used with dictionaries, sets, and generators, however, try to avoid them with complex expressions. Readability is key.
+{{< file "python" "list_comprehension_examples.py" >}}
+{{< highlight "python" >}}
+# List comprehensions can 'map' data to new values: 
+bigger_nums = [num+1 for num in nums]
 
-When making your code more dense, be careful not to make it less readable. More complex logic may be more readable with a full loop.
-[At Google, they never allow nested list comprehensions.](https://google.github.io/styleguide/pyguide.html#274-decision)
+# And they can 'filter' data, skipping some values: 
+even_nums = [num for num in nums if num%2 == 0]
+
+# Or both at once:
+bigger_even_nums = [num+1 for num in nums if num%2 == 0]
+{{< /highlight >}}
+
+Comprehensions can be used with dictionaries, sets, and generators, however, try to avoid them with complex expressions. Readability is key. [At Google, they never allow nested list comprehensions.](https://google.github.io/styleguide/pyguide.html#274-decision)
 
 {{< file "python" "list_comprehension.py" >}}
 {{< highlight "python" >}}

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -47,13 +47,18 @@ In these cases, specifying <code>if some_var is not None:</code> is necessary.
 
 {{< file "python" "null_checks.py" >}}
 {{< highlight "python" >}}
-# Explicit null check: Necessary if the value could be falsey even if not None
+# OK version 🤔: Unnecessary explicit check  
+if user is not None: # user is an object, always truthy if not None
+    print(f"user exists and equals {user}")
+# This is okay if it makes the code safer or more readable.
+
+# Pythonic version 🐍: Shorten when safe ✅
+if user: # user is an object, always truthy if not None
+    print(f"user exists and equals {user}")
+
+# Pythonic version 🐍: Use specific guard if the value could be falsey when not None ✅
 if num_comments is not None: # Could be 0
     print(f"num_comments exists and equals {num_comments}")
-
-# Concise version 🐍: Use simplified if when safe ✅
-if user: # an object
-    print(f"user exists and equals {user}")
 {{< /highlight >}}
 
 
@@ -67,7 +72,7 @@ One way to do this is by using a <code>for</code> loop to iterate over all eleme
 langauges = ["JavaScript", "Python", "Ruby", "PHP", "Rust"]
 my_language = "Rust"
 
-# OK version 🤔 - For loop and a equality check ❌
+# OK version 🤔: For loop and a equality check ❌
 for i in range(len(languages)):
     if my_language == languages[i]:
         print(f"{my_language} is contained in the list")
@@ -197,7 +202,14 @@ x, y, z = some_tuple
 {{< /highlight >}}
 
 ## Ternary Operators
-Python uses <code>if/elif/else</code> blocks for control flow. For example, consider the need to decide on the sign of a variable based on its value. The naive way is to use an <code>if/else</code> block to make the decision. A neater way to simplify this is by using a ternary operator.
+Python uses <code>if/elif/else</code> blocks for control flow. 
+For example, consider the need to decide on the sign of a variable based on its value. 
+The typical way is to use an <code>if/else</code> block to make the decision. 
+
+The ternary operator gives a more concise option, fitting the tree in a single expression.
+
+Shortening code like this can make it easier to read if the logic is simple, but it can make more complex logic harder 
+to understand. Do what you think is best for your situation.
 
 {{< file "python" "ternary_operator.py" >}}
 {{< highlight "python" >}}
@@ -215,7 +227,12 @@ sign = "positive" if (score > 0) else "negative" # parentheses are optional
 {{< /highlight >}}
 
 ## Generators
-[_Generators_](https://docs.python.org/3/howto/functional.html#generators) are a powerful tool to save memory and improve performance. In general, they _yield_ one value at a time and can be iterated over multiple times. Let's imagine we're interested in the sum of the first 42 000 natural numbers. We could use a list comprehension to compute the values and call the built-in <code>sum</code> function. Building a list requires 351064 bytes. Using a generator reduces this value to 112 bytes. That's pretty awesome 🔥.
+[_Generators_](https://docs.python.org/3/howto/functional.html#generators) are a powerful tool to save memory and improve performance. 
+In general, they _yield_ one value at a time and can be iterated over multiple times. 
+Let's imagine we're interested in the sum of the first 42 000 natural numbers. 
+We could use a list comprehension to compute the values and call the built-in <code>sum</code> function. 
+Building a list requires 351064 bytes. 
+Using a generator reduces this value to 112 bytes. That's pretty awesome 🔥.
 
 {{< file "python" "generators.py" >}}
 {{< highlight "python" >}}

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -63,18 +63,19 @@ if num_comments is not None: # Could be 0
 
 
 ## Included values
-In this section, we need to check if a list <code>(L)</code> contains the value of a particular variable <code>(x)</code>.
-One way to do this is by using a <code>for</code> loop to iterate over all elements and check for equality. Python provides a nice shortcut, using the <code>in</code> keyword.
+In this section, we need to check if a list <code>(languages)</code> contains the value of a particular variable <code>(my_language)</code>.
+One way to do this is by using a <code>for</code> loop to iterate over all elements and check for equality. 
+Python provides a nice shortcut, using the <code>in</code> keyword.
 
 {{< file "python" "contains.py" >}}
 {{< highlight "python" >}}
 # Check if a value is contained in a list
-langauges = ["JavaScript", "Python", "Ruby", "PHP", "Rust"]
+languages = ["JavaScript", "Python", "Ruby", "PHP", "Rust"]
 my_language = "Rust"
 
-# OK version 🤔: For loop and a equality check ❌
-for i in range(len(languages)):
-    if my_language == languages[i]:
+# OK version 🤔: For loop and an equality check ❌
+for language in languages:
+    if my_language == language:
         print(f"{my_language} is contained in the list")
 
 # Pythonic version 🐍: Use "if x in L" ✅

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -83,7 +83,7 @@ for language in languages:
     if my_language == language:
         print(f"{my_language} is contained in the list")
 
-# Pythonic version 🐍: Use "if x in L" ✅
+# Pythonic version 🐍: Use "if item in collection" ✅
 if my_language in languages:
     print(f"{my_language} is contained in the list")
 {{< /highlight >}}
@@ -133,13 +133,11 @@ for num in nums:
     if num < 0:
         contains_neg = True
 
-
 # Pythonic way 🐍 - Using the built-in "any" function ✅
 contains_neg = any(num < 0 for num in nums) # True
 
 # Bonus Tip 💡: Python also has a built-in "all" function ✅
 contains_neg = not all(num >= 0 for num in nums) # True
-
 {{< /highlight >}}
 
  - <code>any</code> - Returns True if a condition applies to any element of the iterable. If the iterable is empty, returns False. 
@@ -178,7 +176,7 @@ traits = ["big", "salty", "scary"]
 animals = ["cat", "oyster", "crocodile"]
 
 # OK version 🤔: Index in range ❌ 
-for i in range(len(A)):
+for i in range(len(animals)):
     trait, animal = traits[i], animals[i]
     print(i, trait, animal)
 

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -2,7 +2,7 @@
 title: "Code This, Not That - Python Edition"
 lastmod: 2022-02-20T15:31:36+01:00
 publishdate: 2022-02-20T15:31:36+01:00
-author: Alex Guja
+author: Alex Guja, Toren Darby
 draft: false
 description: 10 Tips to make your code more Pythonic.
 tags:

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -30,22 +30,30 @@ To make life simpler, we’ll use the following key to denote a few categories
 - 🐍 - code that is considered pythonic.
 - 💡 - bonus tips.
 
-## Null checks
+## Null / empty checks
+ 
+Certain "empty" values in Python resolve to <code>False</code> (they're "falsey"), including <code>None</code> (Python's null), <code>0</code>, <code>""</code>, and empty collections.
+Other values resolve to <code>True</code> ("truthy").
 
-A common scenario is checking that a variable isn't empty (or null) before use. In Python, _null_ is denoted by the keyword <code>None</code>. The two code snippets below produce identical results. However, Python supports a simplified null check using the <code>if</code> keyword followed by the name of a variable.
+Because of this, <code>if some_var:</code> can concisely check if a variable is non-empty.
+
+For example, if a variable starts as <code>None</code> and is later initialized to a non-empty value, <code>if some_var:</code> will show if it has been initialized.
+
+Be careful if some falsey values should be treated differently in the logic, 
+like if you want to reject <code>None</code> but accept <code>0</code> or <code>""</code>. 
+In these cases, specifying <code>if some_var is not None:</code> is necessary.
 
 💡 _Bonus Tip_: Use <code>f-strings</code> for string formatting. Initiate an f-string by typing an _f_ immediately before a regular string <code>(f"...")</code>, and place variables inside curly braces. Python will format the result into a string containing the variables.
 
 {{< file "python" "null_checks.py" >}}
 {{< highlight "python" >}}
-# Null check: OK version 🤔 - Explicit "if x is not None" ❌
-n = 42
-if n is not None:
-    print(f"n exists and is equal to {n}")
+# Explicit null check: Necessary if the value could be falsey even if not None
+if num_comments is not None: # Could be 0
+    print(f"num_comments exists and equals {num_comments}")
 
-# Pythonic version 🐍: Use simplified if ✅
-if n:
-    print(f"n exists and is equal to {n}")
+# Concise version 🐍: Use simplified if when safe ✅
+if user: # an object
+    print(f"user exists and equals {user}")
 {{< /highlight >}}
 
 

--- a/hugo/content/lessons/code-this-not-that-python-edition/index.md
+++ b/hugo/content/lessons/code-this-not-that-python-edition/index.md
@@ -96,7 +96,7 @@ When making your code more dense, be careful not to make it less readable. More 
 
 {{< file "python" "list_comprehension.py" >}}
 {{< highlight "python" >}}
-# OK version 🤔 - For loop and append ❌ 
+# OK version 🤔: For loop and append ❌ 
 squares = []
 for num in range(12):
     squares.append(num ** 2)
@@ -122,7 +122,7 @@ Speaking of one-liners, Python provides some built-in functions that can check c
 # Checking for negative values in a list
 nums = [1, 2, 3, 4, 5, -42, 6, 7, 8]
 
-# Inefficinet way 🤔 - Using a for loop and a flag ❌
+# Complex way 🤔: Using a for loop and a flag ❌
 contains_neg = False # flag
 for num in nums:
     if num < 0:
@@ -149,7 +149,7 @@ Python provides a nice syntax for iteration that many users tend to ignore. For 
 # Iterating over a single list
 letters = ["a", "b", "c", "d"]
 
-# OK version 🤔 - Index in range ❌ 
+# OK version 🤔: Index in range ❌ 
 for i in range(len(letters)):
     letter = letters[i]
     print(i, letter)
@@ -172,7 +172,7 @@ using <code>zip</code>. If an index is required, we can use a combination of <co
 traits = ["big", "salty", "scary"]
 animals = ["cat", "oyster", "crocodile"]
 
-# OK version 🤔 - Index in range ❌ 
+# OK version 🤔: Index in range ❌ 
 for i in range(len(A)):
     trait, animal = traits[i], animals[i]
     print(i, trait, animal)
@@ -195,13 +195,13 @@ A more efficient way is to unpack the elements directly.
 # Tuple unpacking
 some_tuple = (1, 2, 3)
 
-# OK version 🤔 - Unpack elements by index ❌
+# OK version 🤔: Unpack elements by index ❌
 x = some_tuple[0]
 y = some_tuple[1]
 z = some_tuple[2]
 
 
-# Pythonic way 🐍 - Unpack elements directly ✅
+# Pythonic version 🐍 - Unpack elements directly ✅
 x, y, z = some_tuple
 {{< /highlight >}}
 
@@ -220,13 +220,13 @@ to understand. Do what you think is best for your situation.
 # Assign a value based on a condition
 score = 42
 
-# OK version 🤔 - if/else blocks ❌ 
+# OK version 🤔: if/else blocks ❌ 
 if score > 0:
     sign = "positive"
 else:
     sign = "negative"
 
-# Pythonic way 🐍 - Use a ternary operator ✅
+# Pythonic version 🐍: Use a ternary operator ✅
 sign = "positive" if (score > 0) else "negative" # parentheses are optional
 {{< /highlight >}}
 
@@ -242,12 +242,12 @@ Using a generator reduces this value to 112 bytes. That's pretty awesome 🔥.
 {{< highlight "python" >}}
 from sys import getsizeof 
 
-# Inefficent way 💩: Using a list ❌
+# Inefficient version 💩: Using a list ❌
 numbers_list = [n for n in range(42_000)]
 sum(numbers_list) # 881979000
 getsizeof(numbers_list) # 351064 bytes
 
-# Efficient way 🔥: Use a generator ✅
+# Efficient version 🔥: Use a generator ✅
 numbers_generator = (num for num in range(42_000))
 sum(numbers_generator) # 881979000
 getsizeof(numbers_generator) # 112 bytes
@@ -258,7 +258,7 @@ Python supports default values for function parameters. If a value for a paramet
 
 {{< file "python" "mutable_default_args.py" >}}
 {{< highlight "python" >}}
-# Mutable default arguments 💩:  Wrong way  ❌
+# Buggy version 💩: Mutable default arguments ❌
 def append_element(elem, previous_list=[]):
     previous_list.append(elem)
     return previous_list
@@ -267,7 +267,7 @@ my_numbers_1 = append_element(21) # [21]
 my_numbers_2 = append_element(42) # [21, 42] - Oops..
 
 
-# Correct way 🔥: Use None ✅
+# Working version 🔥: Use None as a default ✅
 def better_append(elem, previous_list=None):
     if previous_list is None:
         previous_list = []
@@ -285,12 +285,12 @@ In this case, the simple code will run just fine, however, if more complex logic
 
 {{< file "python" "context_managers.py" >}}
 {{< highlight "python" >}}
-# Managing files - using open and f.close() ❌
+# Dangerous version 🤔: Using open and f.close() ❌
 file = open("file.txt", "w")
 file.write("Hi mom!") 
 file.close()
 
-# Pythonic way 🐍 -  Use a context manager ✅
+# Pythonic version 🐍: Use a context manager ✅
 with open("file.txt", "w") as file:
     file.write("Hi mom!") 
 {{< /highlight >}}


### PR DESCRIPTION
Resolves: #715

I went beyond the original feedback and standardized styling and cleaned up language.

The first section, null checks, was mostly rewritten because some of the advice was technically false, and potentially misleading. The trouble is that `if my_var` is not strictly better than `if my_var is not None`, and needs more context. I think my result may have overcomplicated things, but it was the best I could come up with.

Other parts are changed much less.
Feel free to revert or build on any of the changes.