### PR TITLE
fix: (ci) fix gcloud action branch

### DIFF
--- a/.github/workflows/export-firestore-weekly.yml
+++ b/.github/workflows/export-firestore-weekly.yml
@@ -13,7 +13,7 @@ jobs:
   backup:
     runs-on: ubuntu-latest
     steps:
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@main
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true


### PR DESCRIPTION
Fixed the branch of the google-github-actions/setup-gcloud step in the export fireship weekly action from master to main to fix the workflow.