### PR TITLE
Grammatical Typo Fix in hugo/content/cobol.md

### DIFF
--- a/hugo/content/cobol.md
+++ b/hugo/content/cobol.md
@@ -7,6 +7,6 @@ description: Take the Fireship COBOL Enterprise Course
 
 - Launch Date: Aug 21, 2059
 - Preorder price: $23,000 / seat 
-- Unlimited access for [Fireship PRO](/pro) members. 
+- Unlimited access for [Fireship PRO](/pro) members
 
 ![just kidding](https://media2.giphy.com/media/26BRLGB7eWATEI1Ik/giphy.gif?cid=ecf05e47849e176ea461ac559d17cfde23c2b2adb36fcf16&rid=giphy.gif)


### PR DESCRIPTION
Removed period at third bullet point. Since this is a list, a period would not work best here.