### PR TITLE
un-capitalize High-Level to maintain consistency

### DIFF
--- a/hugo/content/tags/python/_index.md
+++ b/hugo/content/tags/python/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Python
-description: Python is a High-Level, interpreted, general purpose, Object Oriented programming language that lets you work more quickly and integrate your systems more effectively.
+description: Python is a high-level, interpreted, general purpose, Object Oriented programming language that lets you work more quickly and integrate your systems more effectively.
 link: https://www.python.org/
 ---


### PR DESCRIPTION
High-Level isn't a proper noun, so it shouldn't be capitalized