### PR TITLE
[firestore automated backups] Update setup-gcloud target

### DIFF
--- a/hugo/content/snippets/firestore-automated-backups.md
+++ b/hugo/content/snippets/firestore-automated-backups.md
@@ -77,7 +77,7 @@ jobs:
   backup:
     runs-on: ubuntu-latest
     steps:
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@main
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true


### PR DESCRIPTION
https://fireship.io/snippets/firestore-automated-backup

This still works great, but the `setup-gcloud` repo has changed, and the branch has changed from master to main

`google-github-actions/setup-gcloud@main`