### PR TITLE
Add autofocus to algolia search field

### DIFF
--- a/app/components/search/algolia-search.svelte
+++ b/app/components/search/algolia-search.svelte
@@ -67,6 +67,7 @@
         class="input"
         name="search"
         type="text"
+        autofocus
         placeholder="Search"
         on:input={search}
       />


### PR DESCRIPTION
The title says it all, 🙃. 

Anyway, made this change because, when using the `/` shortcut, the input modal opens up, but the input field has to be manually focused, and it might be an inconvenience for users who live in the keyboard!