### PR TITLE
Make the scrollbar thumb wider.

### DIFF
--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -1,7 +1,7 @@
 @mixin scrollbar() {
     /* width */
   &::-webkit-scrollbar {
-    @apply w-1.5 h-1.5;
+    @apply w-2.0 h-1.5;
   }
   
   /* Track */


### PR DESCRIPTION
When using a screen with a low density of pixels the scrollbar becomes unclickable due to its small size.

![image](https://user-images.githubusercontent.com/76598237/195997000-5b117260-2450-47cd-93fe-140e72fa47c3.png)
![image](https://user-images.githubusercontent.com/76598237/195997012-fe571a77-1b9e-4408-bcd3-03bc749e2022.png)
![image](https://user-images.githubusercontent.com/76598237/195997045-2093c286-66b6-46c3-b4b2-0e8d149e1f34.png)
 
When we make it slightly larger folks with bad screens get the action back.