### PR TITLE
🔗 Invalid link to portfolio

### DIFF
--- a/content/contributors/shawn-eubanks.md
+++ b/content/contributors/shawn-eubanks.md
@@ -9,7 +9,6 @@ links:
   medium: https://medium.com/@devEube
   twitter:
   github: https://github.com/DevEube
-  portfolio: https://deveube.com
 ---
 
 **devEUBE** = technology geek and expert problem solver. I love to learn anything new, and I am especially interested and passionate about emerging technologies in cloud computing and web development. I am driven and passionate about sharing skills and knowledge with others and helping others succeed using new and innovative technologies. 


### PR DESCRIPTION
https://deveube.com/ no longer redirects correctly. Browser raises SSL error and overriding the same results in default DNS lookup. In other words, **site does not exist**.