### PR TITLE
fix: grammar error in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 npm start
 ```
 
-Check it on on `http://localhost:6969/`.
+Check it on `http://localhost:6969/`.
 
 
 ## Developing Components 
@@ -39,7 +39,7 @@ Export the component from `app/main.ts`:
 export * from './components/hi-mom.svelte';
 ```
 
-Now use it in anywhere in your HTML or Markdown. 
+Now use it anywhere in your HTML or Markdown. 
 
 ```html
 <hi-mom greeting="i made a web component"></hi-mom>


### PR DESCRIPTION
I was going through the documentation, and I noticed two grammar error.

Fixed them all, I don't see any other spelling or grammar errors in README.