### PR TITLE
Fixed typo

### DIFF
--- a/content/lessons/firebase-quickstart/index.md
+++ b/content/lessons/firebase-quickstart/index.md
@@ -342,7 +342,7 @@ service cloud.firestore {
     // Lock down the database
     match /{document=**} {
       allow read, write: if false; 
-    
+    }
     // Allow authorized requests to the things collection
     match /things/{docId} {
       allow write: if request.auth.uid == request.resource.data.uid;


### PR DESCRIPTION
Missing ending curly brackets in Security Rules of content/lessons/firebase-quickstart