### PR TITLE
/content/lessons/firebase-v9-migration/ corrected filename

### DIFF
--- a/content/lessons/firebase-v9-migration/index.md
+++ b/content/lessons/firebase-v9-migration/index.md
@@ -61,7 +61,7 @@ export default firebaseConfig;
 
 v8 and earlier:
 
-{{< file "js" "firebaseConfig.js" >}}
+{{< file "js" "firebaseInit.js" >}}
 ```js
 import firebaseConfig from "./firebaseConfig";
 import firebase from "firebase/app";


### PR DESCRIPTION
changed the wrong filename to correct filename .