### PR TITLE
Fixed typo in content/dashboard.html

### DIFF
--- a/content/dashboard.html
+++ b/content/dashboard.html
@@ -64,7 +64,7 @@ title: Dashboard
 
     <h3 class="font-sans font-bold">How do I get my T-shirt & Sticker?</h3>
 
-    <p>You should have received an email with a link to a Google Form after upgrading. If not, you can access with the <code>/pro</code> command in Discord</p>
+    <p>You should have received an email with a link to a Google Form after upgrading. If not, you can access it with the <code>/pro</code> command in Discord</p>
 
     <h3 class="font-sans font-bold">Can I customize my invoice or receipt details?</h3>
 


### PR DESCRIPTION
The dashboard was missing the word "it" in the following sentence.

You should have received an email with a link to a Google Form after upgrading. If not, you can access **it** with the /pro command in Discord