### PR TITLE
Fix shell command

### DIFF
--- a/content/lessons/deploy-multiple-sites-to-firebase-hosting/index.md
+++ b/content/lessons/deploy-multiple-sites-to-firebase-hosting/index.md
@@ -123,7 +123,7 @@ firebase deploy --only hosting
 Or deploy a single site based on the target name:  
 
 ```shell
-firebase serve --only hosting:french
+firebase deploy --only hosting:french
 ```
 
 


### PR DESCRIPTION
The description above this command in deploy-multiple-sites-to-firebase-hosting says:

> Or deploy a single site based on the target name:
>```shell
>firebase serve --only hosting:french
>```

but `firebase serve` will only allow the site to be served locally.

I believe the intended command was `firebase deploy`, which will _**deploy**_ only a single site based on the target name, as described by the description above.