### PR TITLE
Fixes #1487 - Autofocus search modal input

### DIFF
--- a/app/components/search/algolia-search.svelte
+++ b/app/components/search/algolia-search.svelte
@@ -14,6 +14,9 @@
   let results: any;
   let hits = [];
   let activeHit = 0;
+  let input: any;
+  let hasTypedOnce: boolean;
+  
   onMount(() => {
     return () => {
       window.removeEventListener('keydown', handleSpecialKeys);
@@ -46,6 +49,7 @@
     }
   }
   function handleSpecialKeys(e: KeyboardEvent) {
+    
     if (e.key === 'ArrowUp') {
       goUp();
     }
@@ -56,18 +60,27 @@
       selectHit();
     }
   }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if(!hasTypedOnce) {
+      input.focus();
+      hasTypedOnce = true;
+    }
+    handleSpecialKeys(e)
+  }
+
 </script>
 
-<svelte:window on:keydown={handleSpecialKeys} />
+<svelte:window on:keydown={handleKeyDown} />
 
 <modal-dialog name="search">
   <form>
     {#if $modal === 'search'}
       <input
+        bind:this={input}
         class="input"
         name="search"
         type="text"
-        autofocus
         placeholder="Search"
         on:input={search}
       />


### PR DESCRIPTION
This addresses issue #1487 by adding a proper autofocus on algolia-search modal. It focus on the input field when user types something for the first time.
Pull requests ##1418 add autofocus on search input, but that doesn't seem to be working. Also, this solution produced a warning "Avoid using autofocus".
Pull request ##1442 also resolves this issue but uses setTimeout to autofocus.