### PR TITLE
Update classes-basic.md

### DIFF
--- a/content/courses/dart/classes-basic.md
+++ b/content/courses/dart/classes-basic.md
@@ -46,7 +46,7 @@ You can call static methods on the class itself without creating a new object.
 ```dart
 class Basic {
 
-  static globalData = 'global';
+  static String globalData = 'global';
   static helper() {
       print('helper');
   }


### PR DESCRIPTION
Hey, the dart course is a gem! 
Currently, there is a missing keyword on line 49 in the first lesson under Classes.
It causes the following error

```
Variables must be declared using the keywords 'const', 'final', 'var', or a type name.
Try adding the name of the type of the variable or the keyword 'var'.dart(missing_const_final_var_or_type)
```

This should fix it