### PR TITLE
Updated index to include missing library call

### DIFF
--- a/content/lessons/image-search-engine/index.md
+++ b/content/lessons/image-search-engine/index.md
@@ -44,6 +44,7 @@ Initialize the client and fetch the schema just to make sure the database is up 
 
 {{< file "js" "app.js" >}}
 ```javascript
+import { readFileSync, writeFileSync } from 'fs';
 import weaviate from 'weaviate-ts-client';
 
 const client = weaviate.client({


### PR DESCRIPTION
To use `readFileSync`, you need to import it from the `fs` otherwise the program will run into ReferenceError: readFileSync is not defined and not complete the indexing and querying.