### PR TITLE
Fixed unwanted gaps between the <img-reveal> gifs and the mouse position

### DIFF
--- a/app/components/ui/img-reveal.svelte
+++ b/app/components/ui/img-reveal.svelte
@@ -3,26 +3,27 @@
 <script lang="ts">
     export let src: string;
     let hovered = false;
-    let offset = 0;
+    let imgPosition = 0;
 
     function leave() {
-        hovered = false
-        offset = 0
+        hovered = false;
+        imgPosition = 0;
     }
 
     function moveImg(e) {
-        offset += e.movementX;
+        const containerRect = e.currentTarget.getBoundingClientRect();
+        const imgWidth = e.currentTarget.querySelector('img').getBoundingClientRect().width;
+        imgPosition = e.clientX - containerRect.left - imgWidth / 2;
     }
+
 </script>
 
 <span class="text" on:mouseenter={() => hovered = true} on:mouseleave={leave} on:mousemove={moveImg}>
     <slot></slot>
     {#if hovered}
-        <img {src} alt="special effect" style={`transform: translateX(${offset || 0}px);`} />
+        <img {src} alt="special effect" style={`transform: translateX(${imgPosition}px);`} />
     {/if}
 </span>
-
-
 
 <style lang="scss">
     .text {


### PR DESCRIPTION
Fix: Adjust <img-reveal> component to properly center GIFs above the mouse pointer, eliminating unwanted gaps between the mouse and GIF in img-reveal.svelte

This is my first ever commit as an open-source developper, feel free to give me any feedback !