### PR TITLE
Make Home Sections Smaller

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -49,7 +49,7 @@
 		</scroll-show>
 	</div>
 
-	<div class="md:h-screen grid place-content-center text-center relative" id="truth">
+	<div class="grid place-content-center text-center relative" id="truth">
 
 			<div>
 				<scroll-show repeat="">


### PR DESCRIPTION
The home sections, I feel, take up too much space. I have removed the `md:h-screen` to make the sections smaller and more compact. 

<img width="959" alt="Original" src="https://git
<img width="958" alt="Final" src="https://github.com/fireship-io/fireship.io/assets/52231066/208d5da2-5d4a-4197-a3fb-e93da50bdb53">
hub.com/fireship-io/fireship.io/assets/52231066/1c48b26e-9f7f-42af-8718-dfef044ce58e">
