### PR TITLE
upgrade to compat libraries

### DIFF
--- a/content/lessons/svelte-v3-overview-firebase/index.md
+++ b/content/lessons/svelte-v3-overview-firebase/index.md
@@ -56,7 +56,7 @@ Next, head over the the [Firebase Console](https://console.firebase.google.com/)
 
 {{< file "js" "firebase.js" >}}
 ```js
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import 'firebase/auth';
 import 'firebase/firestore';
 var firebaseConfig = {


### PR DESCRIPTION
This fixes an error:
`[!] RollupError: "default" is not exported by "node_modules/firebase/app/dist/esm/index.esm.js", imported by "src/firebase.js".` 
by upgrading to use the [compat libraries](https://firebase.google.com/docs/web/modular-upgrade)