### PR TITLE
Fix for insufficient rule in usernames uniqueness

### DIFF
--- a/content/lessons/custom-usernames-firebase/index.md
+++ b/content/lessons/custom-usernames-firebase/index.md
@@ -163,7 +163,7 @@ service cloud.firestore {
       function isValidUser(userId) {
         let isOwner = request.auth.uid == userId;
       	let username = request.resource.data.username;
-        let createdValidUsername = existsAfter(/databases/$(database)/documents/usernames/$(username));
+        let createdValidUsername = getAfter(/databases/$(database)/documents/usernames/$(username)).data.uid == userId;
         
         return isOwner && createdValidUsername;
       }


### PR DESCRIPTION
The old rule allowed creating documents in the "users" collection using already existing usernames. But with the uid validation added it's not possible anymore so maintaining a strict 1 to 1 relationship between user and username.