### PR TITLE
Typo fix in "Server Component Fetching", file users/page.tsx

### DIFF
--- a/content/courses/nextjs/db-server-component.md
+++ b/content/courses/nextjs/db-server-component.md
@@ -11,7 +11,7 @@ video_length: 1:20
 
 {{< file "react" "users/page.tsx" >}}
 ```tsx
-import UserCard from '@/components/UserCard/UserCard';
+import UserCard from '@/components/UserCard';
 import styles from './page.module.css';
 import { prisma } from '@/lib/prisma';
 


### PR DESCRIPTION
`import UserCard from '@/components/UserCard/UserCard';`

import with `UserCard/UserCard` is a Typo.
It should be just:
`import UserCard from '@/components/UserCard';`

In the video itself its correct.