### PR TITLE
Quick typo fix in: basics-null-safety.md

### DIFF
--- a/content/courses/dart/basics-null-safety.md
+++ b/content/courses/dart/basics-null-safety.md
@@ -59,8 +59,8 @@ Another possible situation is that you want to assign a *nullable value* TO a *n
 ```dart
 String? answer;
 
-String result = answer; // error;
+String result = answer; // error
 
-String result = answer! // works;
+String result = answer!; // works
 ```
 


### PR DESCRIPTION
Fixed typos in lines 62 and 64. The comments had semicolons which could be a little confusing for new learners and the line 64 was missing a semicolon.