### PR TITLE
fix description for SvelteKit API Routes

### DIFF
--- a/content/courses/sveltekit/basics-api-routes.md
+++ b/content/courses/sveltekit/basics-api-routes.md
@@ -1,6 +1,6 @@
 ---
 title: API Routes
-description: SvelteKit rendering strategies explained
+description: SvelteKit API endpoints explained
 weight: 8
 lastmod: 2023-06-26T10:23:30-09:00
 draft: false


### PR DESCRIPTION
There is a copy paste error in the description of this Video: https://fireship.io/courses/sveltekit/basics-api-routes/