### PR TITLE
Add id attribute to 'Chapters' h2 tag

### DIFF
--- a/layouts/courses/single.html
+++ b/layouts/courses/single.html
@@ -18,7 +18,7 @@
 					{{ if isset .Params "chapter_start" }}
 						<li class="flex py-2 mt-4 px-1 mr-5 border-b-2 border-gray6">
 							<i class="mr-2 not-italic">{{ .Params.emoji }}</i>
-       <h3 id="chapters" class="text-gray3">{{ .Params.chapter_start }}</h3>
+							<h3 id="chapters" class="text-gray3">{{ .Params.chapter_start }}</h3>
 						</li>
 					{{ end}}
 

--- a/layouts/courses/single.html
+++ b/layouts/courses/single.html
@@ -18,7 +18,7 @@
 					{{ if isset .Params "chapter_start" }}
 						<li class="flex py-2 mt-4 px-1 mr-5 border-b-2 border-gray6">
 							<i class="mr-2 not-italic">{{ .Params.emoji }}</i>
-							<h3 class="text-gray3">{{ .Params.chapter_start }}</h3>
+       <h3 id="chapters" class="text-gray3">{{ .Params.chapter_start }}</h3>
 						</li>
 					{{ end}}
 


### PR DESCRIPTION
Clone of https://github.com/kevinlu1248/fireship.io/pull/16, by Sweep, an AI junior dev (https://github.com/sweepai/sweep).

## Description
This PR adds an id attribute to the 'Chapters' h2 tag in the course pages. The id attribute allows users to bookmark the section and directly navigate to it.

## Changes Made
- Modified the `layouts/courses/single.html` file to include the id attribute in the 'Chapters' h2 tag.

Fixes https://github.com/fireship-io/fireship.io/issues/1628