### PR TITLE
hide enterprise plan input arrows

### DIFF
--- a/app/components/payments/buy-lifetime.svelte
+++ b/app/components/payments/buy-lifetime.svelte
@@ -45,7 +45,8 @@
   <div class="controls">
     <button class="btn-o" on:click={() => setSeats(seats - 1)}>-</button>
     <input
-      type="number"
+      type="text"
+      inputmode="numeric"
       bind:value={seats}
       on:change={(e) => setSeats(e.target.value)}
       min="5"


### PR DESCRIPTION
This change resolves #1648 by changing the input attributes to type="text"
      inputmode="numeric"