### PR TITLE
fix(landing-page): Change "Contrib" to "Contributors"

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,7 +19,7 @@
         <a href="/lessons">Labs</a> | 
         <a href="/snippets">Snippets</a> | 
         <a href="/tags">Tags</a> | 
-        <a href="/contributors">Contrib</a> |
+        <a href="/contributors">Contributors</a> |
         <a href="/privacy">Privacy</a> | 
         <a href="/terms">Terms</a>
     </div>


### PR DESCRIPTION
I noticed that the word "Contrib" was on the footer. I assume this was a mistake and changed to "Contributors". If intentional feel free to close the PR. Thanks!