### PR TITLE
(Refactor) import statements for stores

### DIFF
--- a/app/components/global-data.svelte
+++ b/app/components/global-data.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { siteData } from '../stores/data';
+  import { siteData } from '../stores';
 
   export let permalink: string;
   export let next: string;

--- a/app/components/payments/buy-course.svelte
+++ b/app/components/payments/buy-course.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { callUserAPI } from '../../util/firebase';
-  import { currentCourse } from '../../stores/pro';
+  import { currentCourse } from '../../stores';
   let loading = false;
   let url: string;
 

--- a/app/components/search/algolia-search.svelte
+++ b/app/components/search/algolia-search.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import algolia from 'algoliasearch/lite';
-  import { modal } from '../../stores/modal';
+  import { modal } from '../../stores';
   import { router } from '../../main';
   import { onMount } from 'svelte';
 

--- a/app/components/ui/modal-action.svelte
+++ b/app/components/ui/modal-action.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="modal-action" />
 
 <script lang="ts">
-  import { modal } from '../../stores/modal';
+  import { modal } from '../../stores';
   export let type: 'open' | 'close' = 'open';
   export let name = 'default';
   function modalAction() {

--- a/app/components/ui/modal-dialog.svelte
+++ b/app/components/ui/modal-dialog.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="modal-dialog" />
 
 <script lang="ts">
-  import { modal } from '../../stores/modal';
+  import { modal } from '../../stores';
   export let name = 'default';
   export let esc = false;
 

--- a/app/components/ui/navbar-toggle.svelte
+++ b/app/components/ui/navbar-toggle.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="navbar-toggle" />
 
 <script lang="ts">
-    import { showNavbar } from "../../stores/settings";
+    import { showNavbar } from "../../stores";
 </script>
 
 {#if $showNavbar}

--- a/app/components/ui/route-loader.svelte
+++ b/app/components/ui/route-loader.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="route-loader" />
 
 <script lang="ts">
-  import { routeLoading } from '../../stores/loading';
+  import { routeLoading } from '../../stores';
 </script>
 
 

--- a/app/components/ui/toast-message.svelte
+++ b/app/components/ui/toast-message.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { toast } from '../../stores/toast';
+  import { toast } from '../../stores';
   let activate = false;
   let currentToast: any;
   let timeout: NodeJS.Timeout;

--- a/app/components/users/change-email.svelte
+++ b/app/components/users/change-email.svelte
@@ -64,7 +64,7 @@
   <p class="warn">
     Be careful. If you enter the wrong email, you will not be able to access
     your account.
-    <span on:click={() => (show = false)} class="info">nevermind</span>
+    <span on:click={() => (show = false)} class="info">never mind</span>
   </p>
 {:else}
   <span class="info" on:click={() => (show = true)}>change email</span>

--- a/app/components/users/if-access.svelte
+++ b/app/components/users/if-access.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="if-access" />
 
 <script lang="ts">
-  import { canAccess } from '../../stores/user';
+  import { canAccess } from '../../stores';
   export let free = false;
 </script>
 

--- a/app/components/users/if-pro.svelte
+++ b/app/components/users/if-pro.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="if-pro" />
 
 <script lang="ts">
-  import { userData } from '../../stores/user';
+  import { userData } from '../../stores';
 </script>
 
 {#if $userData?.is_pro}

--- a/app/components/users/if-user.svelte
+++ b/app/components/users/if-user.svelte
@@ -3,7 +3,7 @@
 <!-- Is signed in  -->
 
 <script lang="ts">
-  import { user } from '../../stores/user';
+  import { user } from '../../stores';
 </script>
 
 {#if $user}

--- a/app/components/users/user-avatar.svelte
+++ b/app/components/users/user-avatar.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="user-avatar" />
 
 <script lang="ts">
-  import { userData, userProgress } from '../../stores/user';
+  import { userData, userProgress } from '../../stores';
 </script>
 
 <div class="wrap">

--- a/app/components/users/user-data.svelte
+++ b/app/components/users/user-data.svelte
@@ -3,8 +3,7 @@
 <svelte:options tag="user-data" />
 
 <script lang="ts">
-  import { courseByLegacySku } from '../../stores/products';
-  import { user, userData, userProgress } from '../../stores/user';
+  import { courseByLegacySku, user, userData, userProgress } from '../../stores';
   export let field: | 'email' | 'photoURL' | 'displayName' | 'uid' | 'xp' | 'xp-raw' | 'status' | 'expires' | 'courses';
 
   function formatXp(num: number) {

--- a/app/components/video/autoplay-toggle.svelte
+++ b/app/components/video/autoplay-toggle.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="autoplay-toggle" />
 
 <script lang="ts">
-  import { autoplay } from '../../stores/autoplay';
+  import { autoplay } from '../../stores';
   function toggle(e: any) {
 	autoplay.set(e.target.checked)
   }

--- a/app/util/firebase.ts
+++ b/app/util/firebase.ts
@@ -9,9 +9,7 @@ const config = {
   measurementId: "G-VTJV5CVC6K"
 };
 
-import { toast } from '../stores/toast';
-import { modal } from '../stores/modal';
-import { rootURL } from '../stores/data';
+import { toast, modal, rootURL } from '../stores';
 import { initializeApp } from 'firebase/app';
 import {
   getAuth,

--- a/app/util/key-bindings.ts
+++ b/app/util/key-bindings.ts
@@ -1,5 +1,4 @@
-import { showNavbar } from '../stores/settings';
-import { modal } from '../stores/modal';
+import { showNavbar, modal } from '../stores';
 
 const special = 'himom';
 let buffer = '';


### PR DESCRIPTION
Modified the import statements across multiple components and utilities for better maintainability. The goal is to have a neater code base where all the necessary stores are imported directly from '../../stores'. Also, correct the wording from 'nevermind' to 'never mind' in change-email.svelte.