### PR TITLE
Install exact next version used in course

### DIFF
--- a/content/courses/nextjs/project-setup.md
+++ b/content/courses/nextjs/project-setup.md
@@ -17,4 +17,6 @@ Create a new Next.js app that enables the app directory and uses TypeScript.
 {{< file "terminal" "command line" >}}
 ```bash
 npx create-next-app myspace
+cd myspace
+npm install --save-exact next@13.3.1
 ```


### PR DESCRIPTION

I started this course and couldn't follow along with all of the commands in the tutorials because of the Next version updates. Version 14 installs by default when you npx create-next-app. Similar issue with minor versions changes, i.e, 13.5.x.

Hope this helps, let me know if you think there are any changes to make to this :) 