### PR TITLE
Fix filename typo in "Learn Go in 100 lines"

### DIFF
--- a/content/lessons/learn-go-in-100-lines/index.md
+++ b/content/lessons/learn-go-in-100-lines/index.md
@@ -74,7 +74,7 @@ Another option is to use the <code>go</code> command with the <code>run</code> s
 {{< file "terminal" "command line" >}}
 ```text
 
-$ go run helloworld.go
+$ go run hello_world.go
 
 # output
 Hello, world


### PR DESCRIPTION
In the "Hello, World!" section of [Learn Go in 100 lines](https://fireship.io/lessons/learn-go-in-100-lines), the part that introduces the `go run` subcommand is using an inconsistent filename that's missing an underscore:

![Screenshot 2024-08-19 at 11 45 36 PM](https://github.com/user-attachments/assets/a4a52e40-4288-47d8-af07-7f641d218d75)

This PR fixes the typo! ☀️