### PR TITLE
Update index.md

### DIFF
--- a/content/lessons/typescript-design-patterns/index.md
+++ b/content/lessons/typescript-design-patterns/index.md
@@ -30,7 +30,7 @@ Creational patterns are related to the creation of new objects.
 
 ### Singleton
 
-A singleton is an object that can only be instantiated once. It is useful fo implementing a global object that can be accessed from anywhere in the application.
+A singleton is an object that can only be instantiated once. It is useful for implementing a global object that can be accessed from anywhere in the application.
 
 {{< file "ts" "software.ts" >}}
 ```typescript


### PR DESCRIPTION
Spelling error at 2nd line in definition of Singleton design pattern.

The original line was: 
A singleton is an object that can only be instantiated once. It is useful fo implementing a global object that can be accessed from anywhere in the application.

The proposed change is:
A singleton is an object that can only be instantiated once. It is useful **_for_** implementing a global object that can be accessed from anywhere in the application.