### PR TITLE
Update bonus-ansible.md - fix description - replace automatic with automate

### DIFF
--- a/content/courses/linux/bonus-ansible.md
+++ b/content/courses/linux/bonus-ansible.md
@@ -1,6 +1,6 @@
 ---
 title: Ansible
-description: Learn how to automatic sever tasks with Ansible
+description: Learn how to automate sever tasks with Ansible
 weight: 53
 lastmod: 2024-06-20T11:11:30-09:00
 draft: false


### PR DESCRIPTION
Edit the description to say "Learn how to automate server tasks with Ansible" instead of "Learn how to automatic server tasks with Ansible"