### PR TITLE
Typo Fix: 'realted' -> 'related'

### DIFF
--- a/content/courses/js/102-nullish-coalescing.md
+++ b/content/courses/js/102-nullish-coalescing.md
@@ -1,6 +1,6 @@
 ---
 title: Nullish Coalescing
-description: How nullish coalescing is realted to truthy and falsy values
+description: How nullish coalescing is related to truthy and falsy values
 weight: 24
 lastmod: 2022-11-11T10:23:30-09:00
 draft: false


### PR DESCRIPTION
Just a typo fix on the "Nullish Coalescing" section of the javascript course descriptions page. 
https://fireship.io/courses/js/

Thanks!