### PR TITLE
Add a dot in the last line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Now use it in anywhere in your HTML or Markdown.
 - `npm start`: Main dev server. Runs everything you need. 
 - `npm run dev`: Runs components in isolation. Serves `app/index.html` as a playground for components. 
 - `npm run hugo`: Only runs static site. 
-- `npm run build`: Build for production
+- `npm run build`: Build for production.


### PR DESCRIPTION
I noticed that every line in the README.md file ends with a dot except for the last line, so I added it
<img width="903" height="1314" alt="image" src="https://github.com/user-attachments/assets/0ccb5cf7-3e0c-4734-8079-798307042681" />
